### PR TITLE
[fix] 요일 알람 설정 시 is_last 값 설정에 대한 오류 수정 

### DIFF
--- a/MediTime/.idea/compiler.xml
+++ b/MediTime/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/MediTime/.idea/misc.xml
+++ b/MediTime/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/MediTime/app/src/main/java/com/example/meditime/Activity/AddMedicineTimeActivity.kt
+++ b/MediTime/app/src/main/java/com/example/meditime/Activity/AddMedicineTimeActivity.kt
@@ -202,27 +202,29 @@ class AddMedicineTimeActivity : AppCompatActivity() {
                             var calendar_end = calendar.clone() as Calendar
                             while (calendar_end.get(Calendar.DAY_OF_WEEK) != 1) {
                                 calendar_end.add(Calendar.DATE, 1)
-                                var last_record_no = 0
-                                while (calendar_end.compareTo(calendar) != -1) {
-                                    if (dow_arrayList[calendar.get(Calendar.DAY_OF_WEEK) - 1]) {
-                                        val alarm_no = dbCreater.insert_alarm(time_no = item.time_no)
-                                        last_record_no = dbCreater.insertRecord(
-                                            alarm_no = alarm_no.toInt(),
-                                            time_no = item.time_no,
-                                            alarm_datetime = "${calendar.get(Calendar.YEAR)}-${calendar.get(Calendar.MONTH)+1}-${calendar.get(Calendar.DATE)} " +
-                                                    "${calendar.get(Calendar.HOUR_OF_DAY)}:${calendar.get(Calendar.MINUTE)}:${calendar.get(Calendar.SECOND)}"
-                                        ).toInt()
-                                        alarmCallManager.setAlarmRepeating(
-                                            alarm_id = alarm_no.toInt(),
-                                            start_date_str = "${calendar.get(Calendar.YEAR)}-${calendar.get(Calendar.MONTH)+1}-${calendar.get(Calendar.DATE)} " +
-                                                    "${calendar.get(Calendar.HOUR_OF_DAY)}:${calendar.get(Calendar.MINUTE)}:${calendar.get(Calendar.SECOND)}",
-                                            interval_millis = (AlarmManager.INTERVAL_DAY * 7) // 주간 반복 알람 맞추기
-                                        )
-                                    }
-                                    calendar.add(Calendar.DATE, 1)
-                                }
-                                dbCreater.set_record_is_last(last_record_no, 1)
                             }
+
+                            // 이번 주의 해당하는 (오늘 이후의) 요일들에 대해 반복 알람 설정
+                            var last_record_no = 0
+                            while (calendar_end.compareTo(calendar) != -1) {
+                                if (dow_arrayList[calendar.get(Calendar.DAY_OF_WEEK) - 1]) {
+                                    val alarm_no = dbCreater.insert_alarm(time_no = item.time_no)
+                                    last_record_no = dbCreater.insertRecord(
+                                        alarm_no = alarm_no.toInt(),
+                                        time_no = item.time_no,
+                                        alarm_datetime = "${calendar.get(Calendar.YEAR)}-${calendar.get(Calendar.MONTH)+1}-${calendar.get(Calendar.DATE)} " +
+                                                "${calendar.get(Calendar.HOUR_OF_DAY)}:${calendar.get(Calendar.MINUTE)}:${calendar.get(Calendar.SECOND)}"
+                                    ).toInt()
+                                    alarmCallManager.setAlarmRepeating(
+                                        alarm_id = alarm_no.toInt(),
+                                        start_date_str = "${calendar.get(Calendar.YEAR)}-${calendar.get(Calendar.MONTH)+1}-${calendar.get(Calendar.DATE)} " +
+                                                "${calendar.get(Calendar.HOUR_OF_DAY)}:${calendar.get(Calendar.MINUTE)}:${calendar.get(Calendar.SECOND)}",
+                                        interval_millis = (AlarmManager.INTERVAL_DAY * 7) // 주간 반복 알람 맞추기
+                                    )
+                                }
+                                calendar.add(Calendar.DATE, 1)
+                            }
+                            dbCreater.set_record_is_last(last_record_no, 1)
                         }
                         cur_noticeInfo.set_cycle==1 && cur_noticeInfo.re_type==1 -> {
                             // N 일 반복, 반복 alarm 1개 필요


### PR DESCRIPTION
record_table의 is_last는 같은 alarm_no 에서 파상된 record_no 중 마지막 데이터인지 판별하는 데이터입니다. (이는 JobIntentCallService에서 현재 울린 알람이 is_last=1 인 알림이면 다음주에 대한 알람 정보를 자동으로 DB에 추가하기 위해 사용되고 있습니다)

[수정 전] 요일 반복에서 "수, 금, 토"로 요일반복 설정을 하면 "수", "금", "토" 가 모두 is_last가 1임
[수정 후] 요일 반복에서 "수, 금, 토"로 요일반복 설정을 하면 "토" 에만 is_last 값이 1이 됨 